### PR TITLE
Upgrade `strip-ansi`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6027,9 +6027,9 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.1.tgz",
-			"integrity": "sha512-6nC4zf74oXgXJSDmtrIbNXdY5jjLBukH4WN4UC7IC8lX2pUbFvC9n761PhQZt1TPBquz68g3H23O/KkRDOq3Lw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Why is the JavaScript ecosystem so bad. Dependabot cannot update this package because the version that's installed was yanked due to being compromised...